### PR TITLE
feat: Add glob pattern support for folder matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,13 @@
     - Include
         - Field: accepts folder paths from vault.
         - Folder paths where Auto Filename would auto rename files. Separate by new line. Case sensitive.
+        - Use `/**` suffix for recursive matching (includes all subfolders).
         - Default: none
         - Examples:
-            - My Folder
-            - Folder/Sub Folder
-            - /
+            - `My Folder` - only files directly in "My Folder"
+            - `Folder/Sub Folder` - only files directly in "Folder/Sub Folder"
+            - `Notes/**` - files in "Notes" and all its subfolders (recursive)
+            - `/` - files in vault root
     - Use header as filename
         - Toggle
         - Uses the header as filename if the file starts with an H1.

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@
     - Include
         - Field: accepts folder paths from vault.
         - Folder paths where Auto Filename would auto rename files. Separate by new line. Case sensitive.
-        - Use `/**` suffix for recursive matching (includes all subfolders).
+        - Supports glob patterns: `**` for all folders, `folder/**` for recursive matching.
         - Default: none
         - Examples:
+            - `**` - all files in the entire vault
             - `My Folder` - only files directly in "My Folder"
-            - `Folder/Sub Folder` - only files directly in "Folder/Sub Folder"
             - `Notes/**` - files in "Notes" and all its subfolders (recursive)
-            - `/` - files in vault root
+            - `/` - files in vault root only
     - Use header as filename
         - Toggle
         - Uses the header as filename if the file starts with an H1.

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,10 @@ function inTargetFolder(file: TFile, settings: PluginSettings): boolean {
 	if (!filePath) return false;
 
 	for (const folder of settings.includeFolders) {
+		// Support "**" to match all folders
+		if (folder === "**") {
+			return true;
+		}
 		// Support recursive matching with POSIX-style "/**" suffix
 		if (folder.endsWith("/**")) {
 			const baseFolder = folder.slice(0, -3); // Remove "/**"
@@ -277,10 +281,10 @@ class AutoFilenameSettings extends PluginSettingTab {
 		new Setting(this.containerEl)
 			.setName("Include")
 			.setDesc(
-				"Folder paths where Auto Filename would auto rename files. Separate by new line. Case sensitive. Use /** suffix for recursive matching (e.g., folder/** matches folder and all subfolders).",
+				"Folder paths where Auto Filename would auto rename files. Separate by new line. Case sensitive. Use ** for all folders, or folder/** for recursive matching.",
 			)
 			.addTextArea((text) => {
-				text.setPlaceholder("/\nfolder\nfolder/**")
+				text.setPlaceholder("**\nfolder\nfolder/**")
 					.setValue(this.plugin.settings.includeFolders.join("\n"))
 					.onChange(async (value) => {
 						this.plugin.settings.includeFolders = value.split("\n");

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,11 +34,26 @@ let previousFile: string;
 function inTargetFolder(file: TFile, settings: PluginSettings): boolean {
 	if (settings.includeFolders.length === 0) return false; // False if user has no target folder selected
 
-	// True if folder is included
-	if (settings.includeFolders.includes(file.parent?.path as string))
-		return true;
+	const filePath = file.parent?.path;
+	if (!filePath) return false;
 
-	return false; // False if all checks fails
+	for (const folder of settings.includeFolders) {
+		// Support recursive matching with POSIX-style "/**" suffix
+		if (folder.endsWith("/**")) {
+			const baseFolder = folder.slice(0, -3); // Remove "/**"
+			// Match the base folder itself or any subfolder
+			if (filePath === baseFolder || filePath.startsWith(baseFolder + "/")) {
+				return true;
+			}
+		} else {
+			// Exact match (original behavior)
+			if (filePath === folder) {
+				return true;
+			}
+		}
+	}
+
+	return false; // False if all checks fail
 }
 
 export default class AutoFilename extends Plugin {
@@ -262,10 +277,10 @@ class AutoFilenameSettings extends PluginSettingTab {
 		new Setting(this.containerEl)
 			.setName("Include")
 			.setDesc(
-				"Folder paths where Auto Filename would auto rename files. Separate by new line. Case sensitive.",
+				"Folder paths where Auto Filename would auto rename files. Separate by new line. Case sensitive. Use /** suffix for recursive matching (e.g., folder/** matches folder and all subfolders).",
 			)
 			.addTextArea((text) => {
-				text.setPlaceholder("/\nfolder\nfolder/subfolder")
+				text.setPlaceholder("/\nfolder\nfolder/**")
 					.setValue(this.plugin.settings.includeFolders.join("\n"))
 					.onChange(async (value) => {
 						this.plugin.settings.includeFolders = value.split("\n");


### PR DESCRIPTION
## Summary
- Add `**` pattern to match all folders in the vault
- Add `/**` suffix for recursive subfolder matching (e.g., `Notes/**` matches `Notes` and all nested subfolders)
- Original exact-match behavior preserved for backward compatibility

Fixes #18, Closes #8

## Motivation
Currently, users must explicitly list every folder and subfolder they want to watch. This becomes tedious for deep folder structures. With glob patterns, users can now:
- Watch an entire folder tree with a single entry (`Notes/**`)
- Watch the entire vault with `**`

**Note:** This implementation uses zero dependencies—just simple string operations (`endsWith`, `startsWith`)—keeping the plugin fast and lightweight.

## Pattern Reference
| Pattern | Matches |
|---------|---------|
| `**` | All files in the entire vault |
| `folder` | Only files directly in `folder` |
| `folder/**` | Files in `folder` and all subfolders |
| `/` | Files in vault root only |

## Changes
- `src/main.ts`: Updated `inTargetFolder()` to support glob patterns
- `README.md`: Documented new patterns with examples
- Settings UI: Updated description and placeholder text

## Testing
- Verified exact matching still works as before
- Verified `**` matches files in any folder
- Verified `folder/**` matches the base folder and nested subfolders

🤖 Generated with [Claude Code](https://claude.com/claude-code)